### PR TITLE
fix: use npm run format instead of running prettier directly

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -5,7 +5,7 @@
   ...
 }: let
   svelte-check = pkgs.writeShellApplication {
-    name = "npm-format";
+    name = "svelte-format";
     runtimeInputs = [pkgs.svelte-check];
     text = ''
       svelte-check --fail-on-warnings --workspace ${config.git.root}/app --tsconfig ${config.git.root}/app/tsconfig.json


### PR DESCRIPTION
Fixes #2.

Using devenv's default prettier git hook with the necessary configuration causes an error where prettier is unable to find the svelte and tailwind plugins. Trying to create a custom devenv git hook where prettier is run directly with the `exec` option also runs into this issue. `npm run format` circumvents this issue entirely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated code-format and quality-check tooling to the development environment.
  * Introduced pre-commit hooks to run checks and formatting across JS, TS, JSON, Svelte, MD, CSS, and HTML files.
  * Removed older commented hook configurations and streamlined tooling activation for consistent local checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->