### PR TITLE
fix: use correct path for svelte language server

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "svelte.enable-ts-plugin": true,
   "svelte.plugin.svelte.defaultScriptLanguage": "ts",
-  "svelte.language-server.ls-path": "./app/node_modules/.bin/svelte-language-server",
+  "svelte.language-server.ls-path": "./app/node_modules/.bin/svelteserver",
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "[svelte]": {
     "editor.defaultFormatter": "svelte.svelte-vscode"


### PR DESCRIPTION
# Summary

- Change `svelte.language-server.ls-path` from `./app/node_modules/.bin/svelte-language-server` to `./app/node_modules/.bin/svelteserver`, which is the correct name for the svelte-language-server binary installed with npm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment configuration to improve Svelte editor integration and language server compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->