### PR TITLE
chore: add early exit to npm-format hook

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -57,12 +57,14 @@ in {
       name = "eslint";
       entry = "${lib.getExe eslint}";
       files = "^app/.*\\.(js|ts|svelte)$";
+      pass_filenames = true;
     };
 
     svelte-check = {
       name = "svelte-check";
       entry = "${lib.getExe svelte-check}";
       files = "\\.svelte$";
+      pass_filenames = false;
     };
 
     npm-format = {
@@ -70,6 +72,7 @@ in {
       name = "npm-format";
       entry = "${lib.getExe npm-format}";
       files = "\\.(js|ts|json|svelte|md|css|html)$";
+      pass_filenames = true;
     };
   };
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -29,6 +29,11 @@
     name = "npm-format";
     runtimeInputs = [pkgs.nodejs_latest];
     text = ''
+      # Skip the hook if no relevant files are staged
+      if [ "$#" -eq 0 ]; then
+        exit 0
+      fi
+
       cd "${config.git.root}/app"
       npm run format
     '';
@@ -52,7 +57,6 @@ in {
       name = "eslint";
       entry = "${lib.getExe eslint}";
       files = "^app/.*\\.(js|ts|svelte)$";
-      pass_filenames = true;
     };
 
     svelte-check = {
@@ -66,7 +70,6 @@ in {
       name = "npm-format";
       entry = "${lib.getExe npm-format}";
       files = "\\.(js|ts|json|svelte|md|css|html)$";
-      pass_filenames = false;
     };
   };
 


### PR DESCRIPTION
# Summary

- Skip npm-format if no arguments are passed to the hook (i.e. if no relevant staged files exist)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved git hook behavior during commit operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->