### PR TITLE
chore: remove redundant globe radius comment

### DIFF
--- a/app/src/lib/components/globe/Globe.svelte
+++ b/app/src/lib/components/globe/Globe.svelte
@@ -3,7 +3,6 @@
 	import { OrbitControls, useTexture } from '@threlte/extras';
 	import { Texture } from 'three';
 
-	// A larger radius allows for a more detailed normal map, which is important for the visual quality of the globe
 	const globeRadius = 12.8;
 
 	let autoRotate = $state(true);


### PR DESCRIPTION
I can't even remember why I left that in there... it's gone now though.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor internal documentation cleanup with no impact on functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->