### PR TITLE
fix: disable globe rotation while it is loading

### DIFF
--- a/app/src/lib/components/globe/Globe.svelte
+++ b/app/src/lib/components/globe/Globe.svelte
@@ -48,6 +48,8 @@
 		autoRotateSpeed={1}
 		enableDamping
 		enablePan={false}
+		// Disable rotation while loading to further indicate that the globe isn't ready yet
+		enableRotate={isLoaded}
 		maxDistance={globeRadius * 5}
 		minDistance={globeRadius + 0.1}
 		onstart={() => (autoRotate = false)}


### PR DESCRIPTION
Closes #32 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Enhanced the globe's interaction behavior. User-controlled rotation is now available only after texture resources finish loading, preventing premature interactions with incomplete assets. The automatic rotation functionality continues to operate normally during the asset-loading phase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->